### PR TITLE
Fixes #332 and #333

### DIFF
--- a/admin/lib/objects_clients.json
+++ b/admin/lib/objects_clients.json
@@ -107,7 +107,7 @@
                                 "type": "state",
                                 "common": {
                                     "name": "Channel",
-                                    "type": "string",
+                                    "type": "number",
                                     "role": "state",
                                     "read": true,
                                     "write": false,
@@ -694,7 +694,7 @@
                                 "type": "state",
                                 "common": {
                                     "name": "Switch port",
-                                    "type": "string",
+                                    "type": "number",
                                     "role": "state",
                                     "read": true,
                                     "write": false,

--- a/admin/lib/objects_devices.json
+++ b/admin/lib/objects_devices.json
@@ -173,7 +173,7 @@
                                                         "type": "state",
                                                         "common": {
                                                             "name": "POE current",
-                                                            "type": "number",
+                                                            "type": "string",
                                                             "role": "state",
                                                             "read": true,
                                                             "write": false,
@@ -200,7 +200,7 @@
                                                         "type": "state",
                                                         "common": {
                                                             "name": "POE power",
-                                                            "type": "number",
+                                                            "type": "string",
                                                             "role": "state",
                                                             "read": true,
                                                             "write": false,
@@ -227,7 +227,7 @@
                                                         "type": "state",
                                                         "common": {
                                                             "name": "POE voltage",
-                                                            "type": "number",
+                                                            "type": "string",
                                                             "role": "state",
                                                             "read": true,
                                                             "write": false,
@@ -914,7 +914,7 @@
                                             "type": "state",
                                             "common": {
                                                 "name": "Load average 1m",
-                                                "type": "number",
+                                                "type": "string",
                                                 "role": "state",
                                                 "read": true,
                                                 "write": false,
@@ -932,7 +932,7 @@
                                             "type": "state",
                                             "common": {
                                                 "name": "Load average 15m",
-                                                "type": "number",
+                                                "type": "string",
                                                 "role": "state",
                                                 "read": true,
                                                 "write": false,
@@ -950,7 +950,7 @@
                                             "type": "state",
                                             "common": {
                                                 "name": "Load average 5m",
-                                                "type": "number",
+                                                "type": "string",
                                                 "role": "state",
                                                 "read": true,
                                                 "write": false,
@@ -1046,7 +1046,7 @@
                                             "type": "state",
                                             "common": {
                                                 "name": "CPU usage",
-                                                "type": "number",
+                                                "type": "string",
                                                 "role": "state",
                                                 "read": true,
                                                 "write": false,
@@ -1065,7 +1065,7 @@
                                             "type": "state",
                                             "common": {
                                                 "name": "Memory usage",
-                                                "type": "number",
+                                                "type": "string",
                                                 "role": "state",
                                                 "read": true,
                                                 "write": false,
@@ -1084,7 +1084,7 @@
                                             "type": "state",
                                             "common": {
                                                 "name": "Uptime",
-                                                "type": "number",
+                                                "type": "string",
                                                 "role": "state",
                                                 "read": true,
                                                 "write": false,


### PR DESCRIPTION
Quick Fix of all wrong types i found.
This is due too js-controller >3.3
The JSON result from unifi-api returns this values with "3.14" which results in a string. It would may be better to change them too numbers, but i dont know how. I guess it would be much more complicated as my solution.
At least i tried to store the string values in influxdb and it worked nicely in grafana.