### PR TITLE
Raise timeout to 30 seconds to avoid login issues with new unifiOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -260,7 +260,7 @@ class Unifi extends utils.Adapter {
                 username: this.settings.controllerUsername,
                 password: this.settings.controllerPassword,
                 sslverify: !this.settings.ignoreSSLErrors,
-                timeout: 10000
+                timeout: 30000
             });
 
             try {

--- a/main.js
+++ b/main.js
@@ -266,6 +266,7 @@ class Unifi extends utils.Adapter {
             try {
                 await defaultController.login();
             } catch (err) {
+                this.log.debug('Login error: ' + err.code);
                 this.handleError(err, undefined, 'updateUnifiData-login');
 
                 // In case of connection timeout, try again later

--- a/main.js
+++ b/main.js
@@ -266,7 +266,6 @@ class Unifi extends utils.Adapter {
             try {
                 await defaultController.login();
             } catch (err) {
-                this.log.debug('Login error: ' + err.code);
                 this.handleError(err, undefined, 'updateUnifiData-login');
 
                 // In case of connection timeout, try again later


### PR DESCRIPTION
Raise timeout to 30 seconds to avoid login issues with new unifiOS

fixes https://github.com/iobroker-community-adapters/ioBroker.unifi/issues/731